### PR TITLE
Not to encode the payload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 To be released
 
+- Fixed the bug caused by doubly encoded record.
+
 
 0.1.0
 =====

--- a/firefighter/logging.py
+++ b/firefighter/logging.py
@@ -17,7 +17,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import base64
 import logging
 import threading
 import time

--- a/firefighter/logging.py
+++ b/firefighter/logging.py
@@ -108,7 +108,7 @@ class FirehoseHandler(logging.Handler):
         response = None
         kwargs = {
             'DeliveryStreamName': delivery_stream_name,
-            'Records': [{'Data': base64.b64encode(data)} for data in batch]
+            'Records': [{'Data': data} for data in batch]
         }
         for retry in range(max_retries):
             try:


### PR DESCRIPTION
In contrast to the documentation, `put_record_batch()` does encode its
given record data. Therefore, if data that was already encoded in
base64 has given, it will be encoded again before sent to Firehose and
bring weird results.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/firehose.html#Firehose.Client.put_record_batch